### PR TITLE
Add Gemfile.lock to try to pass CI builds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,57 @@
 PATH
   remote: .
   specs:
-    jim (0.1.0)
+    jim (1.0.0b1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (8.1.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    ast (2.4.3)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
     coderay (1.1.3)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
+    csv (3.3.5)
     date (3.4.1)
     diff-lcs (1.6.2)
+    drb (2.2.3)
     erb (5.0.2)
+    ffi (1.17.2)
+    ffi (1.17.2-x86_64-linux-gnu)
+    fileutils (1.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
     io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    json (2.15.2)
+    language_server-protocol (3.17.0.5)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     method_source (1.1.0)
+    minitest (5.26.0)
+    mutex_m (0.3.0)
+    parser (3.3.10.0)
+      ast (~> 2.4.1)
+      racc
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -25,7 +61,14 @@ GEM
     psych (5.2.6)
       date
       stringio
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.3.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rbs (3.9.5)
+      logger
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
@@ -44,7 +87,34 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.6)
+    securerandom (0.4.1)
+    steep (1.10.0)
+      activesupport (>= 5.1)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.17.0.4, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      mutex_m (>= 0.3.0)
+      parser (>= 3.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (~> 3.9)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 5)
+      uri (>= 0.12.0)
     stringio (3.1.7)
+    strscan (3.1.5)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
+    uri (1.0.4)
 
 PLATFORMS
   ruby
@@ -55,7 +125,9 @@ DEPENDENCIES
   jim!
   pry
   rake (~> 13.0)
+  rbs
   rspec (~> 3.0)
+  steep
 
 BUNDLED WITH
    2.6.2


### PR DESCRIPTION
I saw that the CI builds were red, because they didn't like the Gemfile.lock not containing all the gems declared in Gemfile.

This gets us to the point of "failing builds due to no test suite", which is one step closer.