### PR TITLE
Have "jim release" re-use existing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ More advanced features:
 Eventually, there will also be:
 - `jim push`: push the specified gem to the configured host.
 
-### Example Usage
+### Basic Usage
 
 ```console
 puppy@cerberus:~/okay$ jim signin
@@ -92,6 +92,23 @@ Commands
   jim help
   jim pack
 ~$
+```
+
+### Creating A Release
+
+Jim can not currently publish to gem hosts.
+<!--
+If you want to publish to a gem host, you first need to add the following to your gemspec:
+
+```ruby
+  spec.metadata["allowed_push_host"] = "https://gem-host.example/"
+```
+-->
+
+If you want to publish to GitHub Releases, you first need to add the following to your gemspec:
+
+```ruby
+  spec.metadata["github_repo"] = "https://github.com/EXAMPLE_USER/EXAMPLE_REPO"
 ```
 
 ## Development

--- a/jim.gemspec
+++ b/jim.gemspec
@@ -17,9 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.pkg.github.com/duckinator"
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/duckinator/jim"
-
-  spec.metadata["jim/github_repo"] = "duckinator/jim"
-  spec.metadata["jim/gem_host"] = spec.metadata["allowed_push_host"]
+  spec.metadata["github_repo"] = spec.metadata["source_code_uri"]
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Have "jim release" re-use existing configuration for GitHub Packages and RubyGems, instead of duplicating things.