### PR TITLE
Improve Gem::Specification compatibility

### DIFF
--- a/lib/jim.rb
+++ b/lib/jim.rb
@@ -39,6 +39,15 @@ module Jim
         gem_mod.const_set(:Specification, spec_cls)
 
         gem_mod.define_singleton_method(:win_platform?, &Jim::Platform.method(:windows?))
+
+        # Add `Gem::Platform::RUBY`, and raise an exception for all other platforms.
+        gem_mod.const_set(:Platform, Class.new { |c|
+          c.const_set(:UnsupportedPlatformError, Class.new(StandardError))
+          c.const_set(:RUBY, "ruby")
+          c.define_method(:const_missing) { |name|
+            c.const_get(:UnsupportedPlatformError).new("Unsupported platform: #{name}")
+          }
+        })
       })
       # Summon an eldritch being, hoping that `wrap=self` contains some of
       # the impending disaster.

--- a/lib/jim/typed_array.rb
+++ b/lib/jim/typed_array.rb
@@ -34,9 +34,9 @@ module Jim
       val
     end
 
-    def initialize(ary)
+    def initialize(ary=nil)
       super()
-      ary.each { |v| self.push(v) }
+      ary.each { |v| self.push(v) } unless ary.nil?
     end
     def []=(key, val);  super(key, check(val)); end
 

--- a/lib/jim/unsafe_spec.rb
+++ b/lib/jim/unsafe_spec.rb
@@ -76,15 +76,20 @@ module Jim
     array_accessor :executables
     array_accessor :require_paths
     string_accessor :required_ruby_version
+    string_accessor :required_rubygems_version
     string_accessor :version
     array_of_strings_accessor :extra_rdoc_files
     array_of_strings_accessor :rdoc_options
+    string_accessor :platform
+    string_accessor :require_path
 
     def initialize(&block)
       @specification_version = 4
       @metadata = HashOfStringToString.new
       @runtime_dependencies = HashOfStringToAOS.new
       @dev_dependencies = HashOfStringToAOS.new
+      @extra_rdoc_files = ArrayOfStrings.new
+      @rdoc_options = ArrayOfStrings.new
 
       yield self
       self.class.class_variable_get(:@@extract_spec_fn).call(self)
@@ -119,6 +124,7 @@ module Jim
       @@accessors.map { |k, v|
         value = instance_variable_get(:"@#{k}")
         value = value.to_h if value.is_a?(Hash)
+        value = value.to_a if value.is_a?(Array)
 
         if [:required_ruby_version, :required_rubygems_version].include?(k) && value.is_a?(String)
           operator, version = value.strip.split(' ', 2).map(&:strip)


### PR DESCRIPTION
- Add support for Gem::Platform in gemspecs
- Add default values to a few gemspec items
- Add spec.platform and spec.require_path
- Auto-convert TypedArrays to Array on serialization